### PR TITLE
remove applied_date from job applications model

### DIFF
--- a/server/src/models/job_applications.model.js
+++ b/server/src/models/job_applications.model.js
@@ -79,11 +79,6 @@ const JobApplication = sequelize.define(
       allowNull: false,
       defaultValue: {},
     },
-    applied_date: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
   },
   {
     sequelize,


### PR DESCRIPTION
# Description
Since the job applications model already has a createdAt field, we don't need a applied_date field. This PR removes it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
