### PR TITLE
[TCES-68] Create Job Posts Page: Replace mock data with backend endpoints

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -354,7 +354,7 @@ function App() {
               }
             />
             <Route
-              path="/job-posts/add"
+              path="/job-postings/add"
               element={
                 <AuthGuard
                   isAuthenticated={isAuthenticated}

--- a/client/src/components/add-job-post-component/addJobPosting.jsx
+++ b/client/src/components/add-job-post-component/addJobPosting.jsx
@@ -17,7 +17,7 @@ function AddJobPostParent({ currUser }) {
       creation_date: dayjs(),
       close_date: dayjs().add(1, "month"),
       job_type: [],
-      description: "",
+      job_description: "",
     },
     applicationFields: {
       custom_questions: [],

--- a/client/src/components/add-job-post-component/addJobPosting.jsx
+++ b/client/src/components/add-job-post-component/addJobPosting.jsx
@@ -18,6 +18,7 @@ function AddJobPostParent({ currUser }) {
       close_date: dayjs().add(1, "month"),
       job_type: [],
       job_description: "",
+      state: ""
     },
     applicationFields: {
       custom_questions: [],

--- a/client/src/components/add-job-post-component/index.jsx
+++ b/client/src/components/add-job-post-component/index.jsx
@@ -87,7 +87,6 @@ function AddJobPost({ jobPostData, updateJobPostData, currUser }) {
         currUser.userID,
         currUser.userID,
       );
-      console.log(response)
       if (response.status === "success") {
         setResultModalValues(
           postState === DRAFT ? SUCCESS_DRAFT : SUCCESS_PUBLISH,

--- a/client/src/components/add-job-post-component/index.jsx
+++ b/client/src/components/add-job-post-component/index.jsx
@@ -17,7 +17,8 @@ import AddJobDetails from "./job-info-form";
 import AddApplicationFields from "./application-form-fields";
 import { Container, ButtonContainer } from "./index.styles";
 import UserType from "../../prop-types/UserType";
-import createJobPost from "./mockResponse";
+import { createJobPost } from "../../utils/job_posts_api";
+// import createJobPost from "./mockResponse";
 import PostingResultDialog from "./posting-result-dialog";
 
 function AddJobPost({ jobPostData, updateJobPostData, currUser }) {
@@ -33,7 +34,7 @@ function AddJobPost({ jobPostData, updateJobPostData, currUser }) {
   const SUCCESS_DRAFT = {
     isSuccess: true,
     message: "Your job posting was saved",
-    handleClose: () => navigate("/dashboard"),
+    handleClose: () => navigate("/job-postings"),
     buttonMessage: "CLOSE",
   };
   const ERROR_DRAFT = {
@@ -45,7 +46,7 @@ function AddJobPost({ jobPostData, updateJobPostData, currUser }) {
   const SUCCESS_PUBLISH = {
     isSuccess: true,
     message: "Your job posting was published",
-    handleClose: () => navigate("/dashboard"),
+    handleClose: () => navigate("/job-postings"),
     buttonMessage: "CLOSE",
   };
   const ERROR_PUBLISH = {
@@ -82,21 +83,25 @@ function AddJobPost({ jobPostData, updateJobPostData, currUser }) {
     setIsLoading(true);
     try {
       const response = await createJobPost(
-        updatedJobPost,
+        updatedJobPost.jobInfo,
         currUser.userID,
         currUser.userID,
       );
-
-      if (response.ok) {
+      console.log(response)
+      if (response.status === "success") {
+        console.log(1)
         setResultModalValues(
           postState === DRAFT ? SUCCESS_DRAFT : SUCCESS_PUBLISH,
         );
       } else {
+        console.log(2)
         setResultModalValues(postState === DRAFT ? ERROR_DRAFT : ERROR_PUBLISH);
       }
     } catch (error) {
+      console.log(3)
       setResultModalValues(postState === DRAFT ? ERROR_DRAFT : ERROR_PUBLISH);
     } finally {
+      console.log(4)
       setResultOpen(true);
       setIsLoading(false);
     }

--- a/client/src/components/add-job-post-component/index.jsx
+++ b/client/src/components/add-job-post-component/index.jsx
@@ -89,19 +89,15 @@ function AddJobPost({ jobPostData, updateJobPostData, currUser }) {
       );
       console.log(response)
       if (response.status === "success") {
-        console.log(1)
         setResultModalValues(
           postState === DRAFT ? SUCCESS_DRAFT : SUCCESS_PUBLISH,
         );
       } else {
-        console.log(2)
         setResultModalValues(postState === DRAFT ? ERROR_DRAFT : ERROR_PUBLISH);
       }
     } catch (error) {
-      console.log(3)
       setResultModalValues(postState === DRAFT ? ERROR_DRAFT : ERROR_PUBLISH);
     } finally {
-      console.log(4)
       setResultOpen(true);
       setIsLoading(false);
     }

--- a/client/src/components/add-job-post-component/index.jsx
+++ b/client/src/components/add-job-post-component/index.jsx
@@ -77,8 +77,8 @@ function AddJobPost({ jobPostData, updateJobPostData, currUser }) {
 
   const handleSubmit = async (e, postState) => {
     const DRAFT = "Draft";
+    jobPostData.jobInfo.state = postState // eslint-disable-line no-param-reassign
     const updatedJobPost = { ...jobPostData, state: postState };
-    updateJobPostData("state", postState);
 
     setIsLoading(true);
     try {
@@ -232,7 +232,7 @@ function AddJobPost({ jobPostData, updateJobPostData, currUser }) {
                       variant="contained"
                       disabled={isLoading}
                       disableElevation
-                      onClick={() => handleSubmit(null, "Publish")}
+                      onClick={() => handleSubmit(null, "Active")}
                     >
                       PUBLISH
                     </Button>

--- a/client/src/components/add-job-post-component/job-info-form/index.jsx
+++ b/client/src/components/add-job-post-component/job-info-form/index.jsx
@@ -243,14 +243,14 @@ function AddJobDetails({ jobPostData, setJobPostData }) {
         <TextField
           fullWidth
           sx={{ m: 1, width: "96%" }}
-          id="description"
+          id="job_description"
           label="Description"
           multiline
           rows={4}
-          value={jobPostData.description}
+          value={jobPostData.job_description}
           InputLabelProps={{ shrink: true, required: false }}
           helperText="*Required"
-          onChange={(e) => handleInputChange(e.target.value, "description")}
+          onChange={(e) => handleInputChange(e.target.value, "job_description")}
           required
         />
       </Container>

--- a/client/src/components/add-job-post-component/job-info-form/index.jsx
+++ b/client/src/components/add-job-post-component/job-info-form/index.jsx
@@ -227,9 +227,7 @@ function AddJobDetails({ jobPostData, setJobPostData }) {
             sx={{ m: 1, width: "47%" }}
             value={jobPostData.close_date}
             minDate={dayjs()}
-            onChange={(newValue) =>
-              handleInputChange(newValue, jobPostData, "close_date")
-            }
+            onChange={(newValue) => handleInputChange(newValue, "close_date")}
             renderInput={(params) => (
               // eslint-disable-next-line
               <TextField {...params} error={false} helperText="" required />

--- a/client/src/components/add-job-post-component/mockResponse.js
+++ b/client/src/components/add-job-post-component/mockResponse.js
@@ -6,14 +6,14 @@ function mockFetch(jobPostData, currUserId) {
   return new Promise((resolve, reject) => {
     console.log(reject);
     // Simulate error
-    setTimeout(() => {
-      reject(new Error("Failure"));
-    }, timeout);
+    // setTimeout(() => {
+    //   reject(new Error("Failure"));
+    // }, timeout);
 
     // Simulate success
-    // setTimeout(() => {
-    //   resolve({ ok: 200, jobPostData, currUserId });
-    // }, timeout);
+    setTimeout(() => {
+      resolve({ ok: 200, jobPostData, currUserId });
+    }, timeout);
   });
 }
 

--- a/client/src/components/dashboard-component/header-dashboard-component/index.jsx
+++ b/client/src/components/dashboard-component/header-dashboard-component/index.jsx
@@ -89,7 +89,7 @@ function DashboardHeaderComponent({ currUser }) {
                 Add New Client
               </MenuItem>
               <MenuItem
-                onClick={() => handleClose("/job-posts/add")}
+                onClick={() => handleClose("/job-postings/add")}
                 sx={{ justifyContent: "center" }}
               >
                 Add New Job Posting

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -14,7 +14,7 @@ export const COMPENSATION_RATES_FOR_JOB_POSTS = [
   "Hourly",
   "Weekly",
   "Annually",
-  "Commision",
+  "Commission",
   "Base and Commission",
 ];
 

--- a/server/src/controllers/job_posts/addJobPost.js
+++ b/server/src/controllers/job_posts/addJobPost.js
@@ -85,7 +85,7 @@ const addJobPostRequestHandler = async (req, res) => {
       job_description: jobDescription,
       custom_questions: customQuestions,
       creator: req.user.id,
-      state: state === "Draft" ? "Draft" : "Active",
+      state: state
     });
 
     // ! Return a response stating that the object is successfully created.

--- a/server/src/controllers/job_posts/addJobPost.js
+++ b/server/src/controllers/job_posts/addJobPost.js
@@ -16,7 +16,7 @@ const addJobPostRequestHandler = async (req, res) => {
       close_date: closeDate,
       job_description: jobDescription,
       custom_questions: customQuestions,
-      state: state,
+      state,
       // The creator field is excluded because the backend can retrieve the current user's ID from req.user.id.
     } = req.body;
 
@@ -85,7 +85,7 @@ const addJobPostRequestHandler = async (req, res) => {
       job_description: jobDescription,
       custom_questions: customQuestions,
       creator: req.user.id,
-      state: state
+      state,
     });
 
     // ! Return a response stating that the object is successfully created.

--- a/server/src/controllers/job_posts/addJobPost.js
+++ b/server/src/controllers/job_posts/addJobPost.js
@@ -16,7 +16,7 @@ const addJobPostRequestHandler = async (req, res) => {
       close_date: closeDate,
       job_description: jobDescription,
       custom_questions: customQuestions,
-      state = "Draft",
+      state: state,
       // The creator field is excluded because the backend can retrieve the current user's ID from req.user.id.
     } = req.body;
 


### PR DESCRIPTION
# Description

This pull request changes the 'Save as Draft' and 'Publish' buttons when creating a job posting to call the backend API, rather than a mock endpoint. The buttons now also redirect to the job postings page, rather than the dashboard.

Issue #TCES-68 on Linear.app

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

Please delete options that are not applicable.

- [ ] My code follows the style guidelines of this project (required)
- [ ] I have performed a self-review of my code (required)
- [ ] I have linted and formatted my code (required)
- [ ] New and existing unit tests pass locally with my changes (required)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
