### PR TITLE
[TCES-84]  Add an endpoint to fetch a public job post's info

### DIFF
--- a/client/src/utils/job_posts_api.js
+++ b/client/src/utils/job_posts_api.js
@@ -107,7 +107,7 @@ const getOneJobPost = async (jobPostId) => {
   return response;
 };
 
-const getOnePublicJobPost = async (jobPostId) => {
+const getOneActiveJobPost = async (jobPostId) => {
   // eslint-disable-next-line no-useless-catch
   const response = await fetch(
     `${REACT_APP_API_BASE_URL}/job_postings/active/${jobPostId}`,
@@ -143,5 +143,5 @@ module.exports = {
   getAllActiveJobPosts,
   getOneJobPost,
   getAllLocations,
-  getOnePublicJobPost,
+  getOneActiveJobPost,
 };

--- a/client/src/utils/job_posts_api.js
+++ b/client/src/utils/job_posts_api.js
@@ -3,11 +3,11 @@ const { REACT_APP_API_BASE_URL } = process.env;
 const createJobPost = async (jobPostData) => {
   const response = await fetch(`${REACT_APP_API_BASE_URL}/job_postings`, {
     method: "POST",
-    credentials: "include", // Include cookies for cross-origin requests if needed
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(jobPostData), // Convert jobPostData to JSON
+    body: JSON.stringify(jobPostData),
   });
 
   if (!response.ok) {
@@ -22,7 +22,7 @@ const createJobPost = async (jobPostData) => {
 const modifyJobPost = async (modifiedJobPost) => {
   // eslint-disable-next-line no-useless-catch
   const response = await fetch(
-    `${REACT_APP_API_BASE_URL}/job_postings/${modifiedJobPost.job_post_id}`,
+    `${REACT_APP_API_BASE_URL}/job_postings/${modifiedJobPost.job_posting_id}`,
     {
       method: "PUT",
       credentials: "include",
@@ -84,7 +84,6 @@ const getAllActiveJobPosts = async (queryParams) => {
     `${REACT_APP_API_BASE_URL}/job_postings/active?${queryParams}`,
     {
       method: "GET",
-      credentials: "include",
       headers: {
         "Content-Type": "application/json",
       },
@@ -108,13 +107,26 @@ const getOneJobPost = async (jobPostId) => {
   return response;
 };
 
+const getOnePublicJobPost = async (jobPostId) => {
+  // eslint-disable-next-line no-useless-catch
+  const response = await fetch(
+    `${REACT_APP_API_BASE_URL}/job_postings/active/${jobPostId}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  return response;
+};
+
 const getAllLocations = async () => {
   // eslint-disable-next-line no-useless-catch
   const response = await fetch(
     `${REACT_APP_API_BASE_URL}/job_postings/locations`,
     {
       method: "GET",
-      credentials: "include",
       headers: {
         "Content-Type": "application/json",
       },
@@ -131,4 +143,5 @@ module.exports = {
   getAllActiveJobPosts,
   getOneJobPost,
   getAllLocations,
+  getOnePublicJobPost,
 };

--- a/server/src/controllers/job_posts/deleteJobPost.js
+++ b/server/src/controllers/job_posts/deleteJobPost.js
@@ -4,7 +4,7 @@ const { deleteFileFromS3 } = require("../../utils/s3");
 
 const deleteJobPostHandler = async (req, res) => {
   // ! Delete a Job Post and all of its information regardless of close date.
-  // ! Delete any Job Applications associated with this Job Post (i.e job_post_id === given ID in path parameters).
+  // ! Delete any Job Applications associated with this Job Post (i.e job_posting_id === given ID in path parameters).
 
   const { job_posting_id: jobPostId } = req.params;
 

--- a/server/src/controllers/job_posts/getAllActiveJobPosts.js
+++ b/server/src/controllers/job_posts/getAllActiveJobPosts.js
@@ -20,8 +20,8 @@ const getAllActiveJobPostsRequestHandler = async (req, res) => {
     }
 
     if (job_type) {
-      query.job_type = Sequelize.literal(  
-        `JSON_CONTAINS(job_postings.job_type, '["${job_type}"]')`
+      query.job_type = Sequelize.literal(
+        `JSON_CONTAINS(job_postings.job_type, '["${job_type}"]')`,
       );
     }
 

--- a/server/src/controllers/job_posts/getOneActiveJobPost.js
+++ b/server/src/controllers/job_posts/getOneActiveJobPost.js
@@ -36,11 +36,28 @@ const getJobPostRequestHandler = async (req, res) => {
       "state",
     ];
 
+    console.log(job_posting_id);
+
     // Get one Job Posts
     const jobPost = await JobPosting.findOne({
       where: { id: job_posting_id },
       attributes: requiredFields,
     });
+
+    console.log(jobPost);
+
+    if (!jobPost) {
+      return res
+        .status(404)
+        .json({ message: `No job post with id ${job_posting_id} found.` });
+    }
+
+    // Check if this is a public job post
+    if (jobPost.state !== "Active") {
+      return res
+        .status(403)
+        .json({ message: "This job post is not publicly available." });
+    }
 
     // -------- Response:
     const response = {

--- a/server/src/controllers/job_posts/getOneActiveJobPost.js
+++ b/server/src/controllers/job_posts/getOneActiveJobPost.js
@@ -36,27 +36,16 @@ const getJobPostRequestHandler = async (req, res) => {
       "state",
     ];
 
-    console.log(job_posting_id);
-
     // Get one Job Posts
     const jobPost = await JobPosting.findOne({
       where: { id: job_posting_id },
       attributes: requiredFields,
     });
 
-    console.log(jobPost);
-
-    if (!jobPost) {
+    if (!jobPost || jobPost.state !== "Active") {
       return res
         .status(404)
         .json({ message: `No job post with id ${job_posting_id} found.` });
-    }
-
-    // Check if this is a public job post
-    if (jobPost.state !== "Active") {
-      return res
-        .status(403)
-        .json({ message: "This job post is not publicly available." });
     }
 
     // -------- Response:

--- a/server/src/controllers/job_posts/getOneJobPost.js
+++ b/server/src/controllers/job_posts/getOneJobPost.js
@@ -42,6 +42,12 @@ const getJobPostRequestHandler = async (req, res) => {
       attributes: requiredFields,
     });
 
+    if (!jobPost) {
+      return res
+        .status(404)
+        .json({ message: `No job post with id ${job_posting_id} found.` });
+    }
+
     // -------- Response:
     const response = {
       status: "success",

--- a/server/src/controllers/job_posts/updateJobPost.js
+++ b/server/src/controllers/job_posts/updateJobPost.js
@@ -12,14 +12,14 @@ const updateJobPostsRequestHandler = async (req, res) => {
 
   try {
     // Get Job Id
-    const jobPostId = req?.params?.job_post_id
-      ? parseInt(req.params.job_post_id, 10)
+    const jobPostId = req?.params?.job_posting_id
+      ? parseInt(req.params.job_posting_id, 10)
       : null;
 
     if (!jobPostId) {
       return res.status(400).json({
         status: "fail",
-        message: "Invalid or missing job_post_id.",
+        message: "Invalid or missing job_posting_id.",
       });
     }
 

--- a/server/src/routes/job_posts.js
+++ b/server/src/routes/job_posts.js
@@ -18,7 +18,7 @@ const isLoggedIn = require("../middlewares/auth/isLoggedIn");
 
 const getAllLocationsRequestHandler = require("../controllers/job_posts/getAllLocations");
 
-const getPublicJobPostRequestHandler = require("../controllers/job_posts/getOneActiveJobPost");
+const getActiveJobPostRequestHandler = require("../controllers/job_posts/getOneActiveJobPost");
 
 /**
  * Get Active Job Posts for a specific location and/or specific job type, and sort by application_close_date
@@ -41,7 +41,7 @@ router.get("/locations", getAllLocationsRequestHandler);
  * Expected parameters:
  * @type string {params.job_posting_id}
  */
-router.get("/active/:job_posting_id", getPublicJobPostRequestHandler);
+router.get("/active/:job_posting_id", getActiveJobPostRequestHandler);
 
 /**
  * Add a New Job Posting

--- a/server/src/routes/job_posts.js
+++ b/server/src/routes/job_posts.js
@@ -18,6 +18,8 @@ const isLoggedIn = require("../middlewares/auth/isLoggedIn");
 
 const getAllLocationsRequestHandler = require("../controllers/job_posts/getAllLocations");
 
+const getPublicJobPostRequestHandler = require("../controllers/job_posts/getOneActiveJobPost");
+
 /**
  * Get Active Job Posts for a specific location and/or specific job type, and sort by application_close_date
  * Expected parameters:
@@ -33,6 +35,13 @@ router.get("/active", getAllActiveJobPostsRequestHandler);
  * Get all possible locations across all jobs
  */
 router.get("/locations", getAllLocationsRequestHandler);
+
+/**
+ * Get a public job posting
+ * Expected parameters:
+ * @type string {params.job_posting_id}
+ */
+router.get("/active/:job_posting_id", getPublicJobPostRequestHandler);
 
 /**
  * Add a New Job Posting
@@ -124,18 +133,18 @@ router.post("/", isLoggedIn, addJobPostRequestHandler);
 router.get("/", isLoggedIn, getAllJobPostsRequestHandler);
 
 /*
- * Get a specific job post's info, with id job_post_id
+ * Get a specific job post's info, with id job_posting_id
  *
  * Expected parameters:
- * @type integer (in url) {params.job_post_id}
+ * @type integer (in url) {params.job_posting_id}
  */
-router.get("/:job_post_id", isLoggedIn, getJobPostRequestHandler);
+router.get("/:job_posting_id", isLoggedIn, getJobPostRequestHandler);
 
 /**
- * Update a specific job post's info, with id job_post_id
+ * Update a specific job post's info, with id job_posting_id
  *
  * Expected parameters:
- * @type string {params.job_post_id}
+ * @type string {params.job_posting_id}
  * Expected body parameters:
  * @type JobPost {params.body}
  *    <--
@@ -143,7 +152,7 @@ router.get("/:job_post_id", isLoggedIn, getJobPostRequestHandler);
  *      note: any value you do not pass in will be left unchanged
  *      For updating status from Draft to Active, all other fields must be filled in.
  */
-router.put("/:job_post_id", isLoggedIn, updateJobPostRequestHandler);
+router.put("/:job_posting_id", isLoggedIn, updateJobPostRequestHandler);
 
 /**
  * Delete a Job Post and its Associated Job Applications

--- a/server/test/controllers/job_posts/getOneActiveJobPost.test.js
+++ b/server/test/controllers/job_posts/getOneActiveJobPost.test.js
@@ -103,9 +103,9 @@ describe("getActiveJobPostRequestHandler test suite", () => {
 
       await getActiveJobPostRequestHandler(mockReq, mockRes);
 
-      expect(mockRes.statusCode).toBe(403);
+      expect(mockRes.statusCode).toBe(404);
       expect(mockRes.response).toMatchObject({
-        message: "This job post is not publicly available.",
+        message: "No job post with id 124 found.",
       });
     });
 

--- a/server/test/controllers/job_posts/getOneActiveJobPost.test.js
+++ b/server/test/controllers/job_posts/getOneActiveJobPost.test.js
@@ -3,15 +3,15 @@ import { expect, describe, it, afterEach, beforeEach } from "vitest";
 const mock = require("mock-require");
 const mockJobPosting = require("../../mocks/mockGetOneJobPost");
 
-let getJobPostRequestHandler;
+let getActiveJobPostRequestHandler;
 
 beforeEach(() => {
   // Mock the JobPosting model
   mock("../../../src/models/job_posts.model", mockJobPosting);
 
   // Re-require the handler to apply the mock
-  getJobPostRequestHandler = mock.reRequire(
-    "../../../src/controllers/job_posts/getOneJobPost",
+  getActiveJobPostRequestHandler = mock.reRequire(
+    "../../../src/controllers/job_posts/getOneActiveJobPost",
   );
 });
 
@@ -20,7 +20,7 @@ afterEach(() => {
   mock.stop("../../../src/models/job_posts.model");
 });
 
-describe("getJobPostRequestHandler test suite", () => {
+describe("getActiveJobPostRequestHandler test suite", () => {
   const mockRes = {
     status: (code) => {
       mockRes.statusCode = code;
@@ -48,7 +48,7 @@ describe("getJobPostRequestHandler test suite", () => {
         params: { job_posting_id: 123 },
       };
 
-      await getJobPostRequestHandler(mockReq, mockRes);
+      await getActiveJobPostRequestHandler(mockReq, mockRes);
 
       expect(mockRes.statusCode).toBe(200);
       expect(mockRes.response).toMatchObject({
@@ -67,9 +67,9 @@ describe("getJobPostRequestHandler test suite", () => {
         params: { job_posting_id: 999 },
       };
 
-      await getJobPostRequestHandler(mockReq, mockRes);
+      await getActiveJobPostRequestHandler(mockReq, mockRes);
 
-      expect(mockRes.statusCode).toBe(404); // If the response format changes, adjust this.
+      expect(mockRes.statusCode).toBe(404);
       expect(mockRes.response).toMatchObject({
         message: "No job post with id 999 found.",
       });
@@ -81,11 +81,31 @@ describe("getJobPostRequestHandler test suite", () => {
         params: { job_posting_id: 123 },
       };
 
-      await getJobPostRequestHandler(mockReq, mockRes);
+      await getActiveJobPostRequestHandler(mockReq, mockRes);
 
       expect(mockRes.statusCode).toBe(405);
       expect(mockRes.response).toMatchObject({
         message: "Method not allowed, only GET methods allowed.",
+      });
+    });
+
+    it("Returns 404 if the job post is not active", async () => {
+      const mockReq = {
+        method: "GET",
+        params: { job_posting_id: 124 },
+      };
+
+      mockJobPosting.findOne = async () => ({
+        id: 124,
+        title: "Inactive Job",
+        state: "Inactive",
+      });
+
+      await getActiveJobPostRequestHandler(mockReq, mockRes);
+
+      expect(mockRes.statusCode).toBe(403);
+      expect(mockRes.response).toMatchObject({
+        message: "This job post is not publicly available.",
       });
     });
 
@@ -99,7 +119,7 @@ describe("getJobPostRequestHandler test suite", () => {
         params: { job_posting_id: 123 },
       };
 
-      await getJobPostRequestHandler(mockReq, mockRes);
+      await getActiveJobPostRequestHandler(mockReq, mockRes);
 
       expect(mockRes.statusCode).toBe(500);
       expect(mockRes.response).toMatchObject({

--- a/server/test/controllers/job_posts/getOneJobPost.test.js
+++ b/server/test/controllers/job_posts/getOneJobPost.test.js
@@ -44,7 +44,7 @@ describe("getJobPostRequestHandler test suite", () => {
     it("Returns job post details successfully", async () => {
       const mockReq = {
         method: "GET",
-        params: { job_post_id: 123 },
+        params: { job_posting_id: 123 },
       };
 
       await getJobPostRequestHandler(mockReq, mockRes);
@@ -63,7 +63,7 @@ describe("getJobPostRequestHandler test suite", () => {
     it("Returns 404 if the job post is not found", async () => {
       const mockReq = {
         method: "GET",
-        params: { job_post_id: 999 },
+        params: { job_posting_id: 999 },
       };
 
       await getJobPostRequestHandler(mockReq, mockRes);
@@ -79,7 +79,7 @@ describe("getJobPostRequestHandler test suite", () => {
     it("Returns 405 if the method is not GET", async () => {
       const mockReq = {
         method: "POST",
-        params: { job_post_id: 123 },
+        params: { job_posting_id: 123 },
       };
 
       await getJobPostRequestHandler(mockReq, mockRes);
@@ -97,7 +97,7 @@ describe("getJobPostRequestHandler test suite", () => {
 
       const mockReq = {
         method: "GET",
-        params: { job_post_id: 123 },
+        params: { job_posting_id: 123 },
       };
 
       await getJobPostRequestHandler(mockReq, mockRes);

--- a/server/test/controllers/job_posts/updateJobPost.test.js
+++ b/server/test/controllers/job_posts/updateJobPost.test.js
@@ -45,7 +45,7 @@ describe("updateJobPostsRequestHandler test suite", () => {
   it("Updates a job post successfully", async () => {
     const mockReq = {
       method: "PUT",
-      params: { job_post_id: 123 },
+      params: { job_posting_id: 123 },
       body: { title: "Updated Title" },
     };
 
@@ -59,10 +59,10 @@ describe("updateJobPostsRequestHandler test suite", () => {
     });
   });
 
-  it("Returns 400 for invalid job_post_id", async () => {
+  it("Returns 400 for invalid job_posting_id", async () => {
     const mockReq = {
       method: "PUT",
-      params: { job_post_id: "invalid" },
+      params: { job_posting_id: "invalid" },
     };
 
     await updateJobPostsRequestHandler(mockReq, mockRes);
@@ -70,14 +70,14 @@ describe("updateJobPostsRequestHandler test suite", () => {
     expect(mockRes.statusCode).toBe(400);
     expect(mockRes.response).toMatchObject({
       status: "fail",
-      message: "Invalid or missing job_post_id.",
+      message: "Invalid or missing job_posting_id.",
     });
   });
 
   it("Returns 404 if the job post is not found", async () => {
     const mockReq = {
       method: "PUT",
-      params: { job_post_id: 999 },
+      params: { job_posting_id: 999 },
     };
 
     await updateJobPostsRequestHandler(mockReq, mockRes);
@@ -92,7 +92,7 @@ describe("updateJobPostsRequestHandler test suite", () => {
   it("Returns 403 if trying to update the job post ID", async () => {
     const mockReq = {
       method: "PUT",
-      params: { job_post_id: 123 },
+      params: { job_posting_id: 123 },
       body: { id: 999 },
     };
 
@@ -108,7 +108,7 @@ describe("updateJobPostsRequestHandler test suite", () => {
   it("Returns 400 if required fields are missing when changing state to Active", async () => {
     const mockReq = {
       method: "PUT",
-      params: { job_post_id: 123 },
+      params: { job_posting_id: 123 },
       body: { state: "Active" }, // Missing required fields
     };
 
@@ -130,7 +130,7 @@ describe("updateJobPostsRequestHandler test suite", () => {
   it("Returns 400 if the creator does not exist", async () => {
     const mockReq = {
       method: "PUT",
-      params: { job_post_id: 123 },
+      params: { job_posting_id: 123 },
       body: { creator: 999 },
     };
 
@@ -146,7 +146,7 @@ describe("updateJobPostsRequestHandler test suite", () => {
   it("Returns 405 for non-PUT requests", async () => {
     const mockReq = {
       method: "POST",
-      params: { job_post_id: 123 },
+      params: { job_posting_id: 123 },
     };
 
     await updateJobPostsRequestHandler(mockReq, mockRes);
@@ -160,7 +160,7 @@ describe("updateJobPostsRequestHandler test suite", () => {
   it("Handles server errors gracefully", async () => {
     const mockReq = {
       method: "PUT",
-      params: { job_post_id: 123 },
+      params: { job_posting_id: 123 },
       body: { title: "Server Error Test" },
     };
 


### PR DESCRIPTION
# Description

- Added a new endpoint `/active/:job_posting_id` to get  a public job post's info
- Added tests for this endpoint
- renamed all instances of query parameter `job_post_id` to `job_posting_id`
- Added a case to `getOneJobPost` to return a 404 error when no job post is found

Issue: https://linear.app/tces/issue/TCES-84/split-the-get-endpoint-to-fetch-one-job-posts-info-into-2-separate 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

Please delete options that are not applicable.

- [x] My code follows the style guidelines of this project (required)
- [x] I have performed a self-review of my code (required)
- [x] I have linted and formatted my code (required)
- [x] New and existing unit tests pass locally with my changes (required)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
